### PR TITLE
Correcting test script to copy the right folder

### DIFF
--- a/test-plugin.sh
+++ b/test-plugin.sh
@@ -13,7 +13,7 @@ cd ..
 
 # Copy in node_modules and faas provider developer version
 cp -r node_modules driver/faas-func/
-cp -r faas driver/faas-func/node_modules/serverless-faas
+cp -r lib driver/faas-func/node_modules/serverless-faas
 
 cd driver/faas-func
 #node --inspect-brk=0.0.0.0:9229 /home/austin/.nvm/versions/node/v8.4.0/bin/sls package


### PR DESCRIPTION
When executing `./test-plugin.sh`, I was getting this error:

```
Serverless: Downloading and installing "openfaas-nodejs"...
Serverless: Successfully installed "faas-func" 
cp: faas: No such file or directory
 
  Serverless Error ---------------------------------------
 
  Serverless plugin "serverless-faas" not found. Make sure it's installed and listed in the "plugins" section of your serverless config file.

```

With the change, the script runs correctly.